### PR TITLE
Patch base swerve functionality

### DIFF
--- a/src/main/java/frc/robot/subsystems/swerve/Drive.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Drive.java
@@ -88,22 +88,16 @@ public class Drive extends SubsystemBase {
     /* use kinematics to get desired module states */
     ChassisSpeeds discretizedSpeeds =
         ChassisSpeeds.discretize(targetSpeeds, Constants.PERIODIC_LOOP_SEC);
-    /* ChassisSpeeds discretizedSpeeds = targetSpeeds; // FIXME
-    discretizedSpeeds.discretize(Constants.PERIODIC_LOOP_SEC); */
 
     SwerveModuleState[] moduleTargetStates = KINEMATICS.toSwerveModuleStates(discretizedSpeeds);
     SwerveDriveKinematics.desaturateWheelSpeeds(
         moduleTargetStates, DRIVE_CONFIG.maxLinearVelocity());
 
-    SwerveModuleState[] optimizedTargetStates = new SwerveModuleState[4];
-
     for (int i = 0; i < modules.length; i++) {
-      optimizedTargetStates[i] = moduleTargetStates[i];
-      optimizedTargetStates[i].optimize(modules[i].getSteerHeading());
-      modules[i].runToSetpoint(optimizedTargetStates[i]);
+      modules[i].runToSetpoint(moduleTargetStates[i]);
     }
 
-    Logger.recordOutput("Swerve/ModuleStates/Optimized", optimizedTargetStates);
+    Logger.recordOutput("Swerve/ModuleStates", moduleTargetStates);
     Logger.recordOutput("Swerve/TargetSpeeds", targetSpeeds);
     Logger.recordOutput("Swerve/DriveMode", driveMode);
   }

--- a/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
@@ -49,7 +49,7 @@ public class DriveConstants {
           new ModuleConfig(5, 6, 1, new Rotation2d(-1.608), false, false),
           new ModuleConfig(7, 8, 2, new Rotation2d(-0.175), false, true),
           new ModuleConfig(11, 12, 3, new Rotation2d(2.901), false, false),
-          new ModuleConfig(9, 10, 4, new Rotation2d(1.505), false, true)
+          new ModuleConfig(9, 10, 4, new Rotation2d(2.241), false, true)
         };
         case DEV -> new ModuleConfig[] {
           new ModuleConfig(2, 1, 27, new Rotation2d(0), true, false),

--- a/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
@@ -46,10 +46,10 @@ public class DriveConstants {
   public static final ModuleConfig[] MODULE_CONFIGS =
       switch (getRobotType()) {
         case COMP -> new ModuleConfig[] {
-          new ModuleConfig(5, 6, 1, new Rotation2d(1.1397), true, false),
-          new ModuleConfig(7, 8, 2, new Rotation2d(0.8038), true, true),
-          new ModuleConfig(11, 12, 3, new Rotation2d(1.4327), true, false),
-          new ModuleConfig(9, 10, 4, new Rotation2d(-1.8208), true, true)
+          new ModuleConfig(5, 6, 1, new Rotation2d(-1.608), false, false),
+          new ModuleConfig(7, 8, 2, new Rotation2d(-0.175), false, true),
+          new ModuleConfig(11, 12, 3, new Rotation2d(2.901), false, false),
+          new ModuleConfig(9, 10, 4, new Rotation2d(1.505), false, true)
         };
         case DEV -> new ModuleConfig[] {
           new ModuleConfig(2, 1, 27, new Rotation2d(0), true, false),
@@ -68,11 +68,11 @@ public class DriveConstants {
   public static final ModuleConstants MODULE_CONSTANTS =
       switch (getRobotType()) {
         case COMP, SIM -> new ModuleConstants(
-            new Gains(0.25, 2.62, 0, 100, 0, 0), // revisit kP
+            new Gains(0, 0, 0, 50, 0, 0), // revisit kP
             new MotionProfileGains(4, 64, 640), // revisit all
-            new Gains(0.3, 0.63, 0, 2, 0, 0), // FIXME placeholder, to do
-            5.357142857142857,
-            21.428571428571427,
+            new Gains(0, 0, 0, 1.5, 0, 0), // FIXME placeholder, to do
+            12.8,
+            6.75,
             3.125);
         case DEV -> new ModuleConstants(
             new Gains(0, 0, 0, 11, 0, 0),

--- a/src/main/java/frc/robot/subsystems/swerve/Module.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Module.java
@@ -22,25 +22,19 @@ public class Module {
   }
 
   public void runToSetpoint(SwerveModuleState targetState) {
+    targetState.optimize(getSteerHeading());
+    targetState.cosineScale(getSteerHeading());
     moduleIO.runSteerPositionSetpoint(targetState.angle.getRadians());
-
-    // reduce "skew" when changing directions ; from Phoenix6
-    double steerError = targetState.angle.getRadians() - getSteerHeading().getRadians();
-    double cosineScalar = Math.cos(steerError);
-    if (cosineScalar < 0) {
-      cosineScalar = 0;
-    }
 
     /* Back out the expected shimmy the drive motor will see */
     /* Find the angular rate to determine what to back out */
     double azimuthTurnRps = inputs.steerVelocityRadsPerSec;
     /* Azimuth turn rate multiplied by coupling ratio provides back-out rps */
-    double driveRateBackOut =
-        azimuthTurnRps * DriveConstants.MODULE_CONSTANTS.couplingGearReduction();
+    double driveRateBackOut = 0;
+    //        azimuthTurnRps * DriveConstants.MODULE_CONSTANTS.couplingGearReduction();
 
     double driveVelocityRads =
-        ((targetState.speedMetersPerSecond * cosineScalar)
-                / DriveConstants.DRIVE_CONFIG.wheelRadius())
+        ((targetState.speedMetersPerSecond) / DriveConstants.DRIVE_CONFIG.wheelRadius())
             + driveRateBackOut;
 
     moduleIO.runDriveVelocitySetpoint(driveVelocityRads);

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOTalonFX.java
@@ -11,6 +11,7 @@ import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -77,8 +78,10 @@ public class ModuleIOTalonFX implements ModuleIO {
             : InvertedValue.CounterClockwise_Positive;
 
     driveConfig.Feedback.SensorToMechanismRatio = MODULE_CONSTANTS.driveReduction();
-    steerConfig.Feedback.SensorToMechanismRatio = MODULE_CONSTANTS.steerReduction();
+    // steerConfig.Feedback.SensorToMechanismRatio = MODULE_CONSTANTS.steerReduction();
     steerConfig.ClosedLoopGeneral.ContinuousWrap = true;
+    steerConfig.Feedback.FeedbackRemoteSensorID = config.encoderID();
+    steerConfig.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.RemoteCANcoder;
 
     setDriveGains(MODULE_CONSTANTS.driveGains());
     setSteerGains(MODULE_CONSTANTS.steerGains(), MODULE_CONSTANTS.steerMotionGains());


### PR DESCRIPTION
Change List
- Swerve steer motors now use remote CANCoders for onboard PID control (vs. previously using onboard encoder)
- Refactor some swerve optimizations with new WPILIB 2025 changes
- Update various swerve module constants (still requires extensive tuning)
- Only proven on mini-test bot (using COMP robotType)