### PR TITLE
add thread priorities, CommandScheduler.run() to robotPeriodic()

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -20,6 +20,9 @@ import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
 
+import edu.wpi.first.wpilibj.Threads;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
  * each mode, as described in the TimedRobot documentation. If you change the name of this class or
@@ -78,7 +81,13 @@ public class Robot extends LoggedRobot {
 
   /** This function is called periodically during all modes. */
   @Override
-  public void robotPeriodic() {}
+  public void robotPeriodic() {
+    Threads.setCurrentThreadPriority(true, 99);    
+
+    CommandScheduler.getInstance().run();
+
+    Threads.setCurrentThreadPriority(false, 10);
+  }
 
   /** This function is called once when the robot is disabled. */
   @Override


### PR DESCRIPTION
Change List
- call CommandScheduler.run() in robotPeriodic()
- set thread priority to high to improve loop timings