### PR TITLE
Move Alpha bot constants to DEV RobotType

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -23,7 +23,12 @@ import edu.wpi.first.wpilibj.RobotBase;
 public final class Constants {
   public static final double PERIODIC_LOOP_SEC = 0.02;
 
-  public static RobotType ROBOT_TYPE = RobotType.COMP; // FIXME
+  /* FIXME
+   * as of 2025-01-11
+   * COMP: mini "test" bot
+   * DEV: alpha bot
+   * */
+  public static RobotType ROBOT_TYPE = RobotType.DEV;
 
   /* running mode of robot */
   public static Mode getRobotMode() {

--- a/src/main/java/frc/robot/subsystems/superstructure/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/elevator/ElevatorConstants.java
@@ -6,15 +6,15 @@ import frc.robot.Constants;
 public class ElevatorConstants {
   public static final ElevatorConfig ELEVATOR_CONFIG =
       switch (Constants.getRobotType()) {
-        case COMP -> new ElevatorConfig(37, 9.0 / 4.0);
-        case DEV -> new ElevatorConfig(0, 1); // FIXME
+        case COMP -> new ElevatorConfig(0, 1);
+        case DEV -> new ElevatorConfig(37, 9.0 / 4.0); // FIXME
         case SIM -> new ElevatorConfig(0, 1); // FIXME
       };
 
   public static final PIDGains GAINS =
       switch (Constants.getRobotType()) {
-        case COMP -> new PIDGains(2, 0, .2, 0, 0.09, 0);
-        case DEV -> new PIDGains(0, 0, 0, 0, 0, 0);
+        case COMP -> new PIDGains(0, 0, 0, 0, 0, 0);
+        case DEV -> new PIDGains(2, 0, 0.2, 0, 0.09, 0);
         case SIM -> new PIDGains(0, 0, 0, 0, 0, 0);
       };
 

--- a/src/main/java/frc/robot/subsystems/superstructure/elevator/ElevatorIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/elevator/ElevatorIOTalonFX.java
@@ -1,8 +1,9 @@
 package frc.robot.subsystems.superstructure.elevator;
 
+import static frc.robot.subsystems.superstructure.elevator.ElevatorConstants.*;
+
 import frc.robot.subsystems.superstructure.GenericSuperstructureIOTalonFX;
 import java.util.Optional;
-import static frc.robot.subsystems.superstructure.elevator.ElevatorConstants.*;
 
 public class ElevatorIOTalonFX extends GenericSuperstructureIOTalonFX implements ElevatorIO {
 
@@ -16,13 +17,6 @@ public class ElevatorIOTalonFX extends GenericSuperstructureIOTalonFX implements
         UPPER_EXTENSION_LIMIT,
         UPPER_VOLT_LIMIT,
         LOWER_VOLT_LIMIT);
-    setSlot0(
-        GAINS.kP(),
-        GAINS.kI(),
-        GAINS.kD(),
-        GAINS.kS(),
-        GAINS.kV(),
-        GAINS.kA(),
-        GRAVITY_TYPE);
+    setSlot0(GAINS.kP(), GAINS.kI(), GAINS.kD(), GAINS.kS(), GAINS.kV(), GAINS.kA(), GRAVITY_TYPE);
   }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
@@ -84,7 +84,10 @@ public class DriveConstants {
       };
 
   public static final TrajectoryFollowerConstants TRAJECTORY_CONFIG =
-      new TrajectoryFollowerConstants(0, 0, 0, 0); // FIXME
+      switch (getRobotType()) {
+        case COMP, SIM -> new TrajectoryFollowerConstants(0, 0, 0, 0);
+        case DEV -> new TrajectoryFollowerConstants(0, 0, 0, 0);
+      };
 
   public record DrivebaseConfig(
       double wheelRadius,

--- a/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/DriveConstants.java
@@ -52,10 +52,10 @@ public class DriveConstants {
           new ModuleConfig(9, 10, 4, new Rotation2d(2.311), false, true)
         };
         case DEV -> new ModuleConfig[] {
-          new ModuleConfig(2, 1, 27, new Rotation2d(0), true, false),
-          new ModuleConfig(13, 12, 26, new Rotation2d(0), true, true),
-          new ModuleConfig(4, 3, 24, new Rotation2d(0), true, false),
-          new ModuleConfig(11, 10, 25, new Rotation2d(0), true, true)
+          new ModuleConfig(5, 6, 1, new Rotation2d(1.1612), true, false),
+          new ModuleConfig(7, 8, 2, new Rotation2d(0.8099), true, true),
+          new ModuleConfig(11, 12, 3, new Rotation2d(1.4327), true, false),
+          new ModuleConfig(9, 10, 4, new Rotation2d(-1.8392), true, true)
         };
         case SIM -> new ModuleConfig[] {
           new ModuleConfig(0, 0, 0, new Rotation2d(0), true, false),
@@ -75,8 +75,8 @@ public class DriveConstants {
             6.75,
             3.125);
         case DEV -> new ModuleConstants(
-            new Gains(0, 0, 0, 11, 0, 0),
-            new MotionProfileGains(0, 0, 0),
+            new Gains(0, 0, 0, 50, 0, 0),
+            new MotionProfileGains(4, 64, 640),
             new Gains(0, 0, 0, 1.5, 0, 0),
             5.357142857142857,
             21.428571428571427,


### PR DESCRIPTION
### Change List
- Elevator constants for Alpha bot are under DEV instead of COMP constant
- Calibrated swerve modules, adequate (minor, but noticeable drift)