### PR TITLE
Stabilizing superstructure transitions

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -347,6 +347,7 @@ public class RobotContainer {
             superstructure
                 .goToStateCommand(SuperstructureState.SCORE_L3)
                 .alongWith(new InstantCommand(() -> levelOffsets = LevelOffsets.L3_OFFSET)));
+
     // Go to L4
     new Trigger(
             () ->
@@ -355,8 +356,14 @@ public class RobotContainer {
                     && driverB.povUp().getAsBoolean())
         .onTrue(
             superstructure
-                .goToStateCommand(SuperstructureState.SCORE_L4)
+                .goToStateCommand(SuperstructureState.PREVENT_TIPPING)
                 .alongWith(new InstantCommand(() -> levelOffsets = LevelOffsets.L4_OFFSET)));
+    new Trigger(
+            () ->
+                driverB
+                    .povUp()
+                    .getAsBoolean()) // only worry about release of this to change anything
+        .onFalse(superstructure.goToStateCommand(SuperstructureState.SCORE_L4));
 
     driverB // ZERO our mechanism
         .a()
@@ -434,20 +441,6 @@ public class RobotContainer {
                         .andThen(superstructure.goToStateCommand(SuperstructureState.INTAKE))));
 
     // Eject Intake - ONLY IF ITS EXACTLY AT INTAKE
-    new Trigger(
-            () ->
-                (superstructure.getTargetState().equals(SuperstructureState.INTAKE)
-                        && superstructure.getCurrentState().equals(SuperstructureState.INTAKE)
-                        && superstructure.superstructureReachedTarget())
-                    && driverB.rightTrigger().getAsBoolean())
-        .onTrue(
-            rollers
-                .setTargetCommand(RollerState.EJECT_TOP)
-                .andThen(
-                    new WaitCommand(0.5)
-                        .andThen(rollers.setTargetCommand(RollerState.INTAKE))
-                        .andThen(superstructure.goToStateCommand(SuperstructureState.INTAKE))));
-    // Eject if not at L1 or L2 or Intake
     new Trigger(
             () ->
                 (superstructure.getTargetState().equals(SuperstructureState.INTAKE)

--- a/src/main/java/frc/robot/subsystems/superstructure/GenericSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/GenericSuperstructure.java
@@ -1,5 +1,7 @@
 package frc.robot.subsystems.superstructure;
 
+import java.util.Optional;
+
 import org.littletonrobotics.junction.Logger;
 
 public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarget> {
@@ -9,6 +11,7 @@ public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarge
 
   public enum ControlMode {
     POSITION,
+    POSITION_MANUAL,
     STOP;
   }
 
@@ -16,6 +19,8 @@ public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarge
 
   protected final String name;
   protected final GenericSuperstructureIO superstructureIO;
+
+  private Optional<Double> positionTargetManual = Optional.empty();
 
   private GenericSuperstructureIOInputsAutoLogged inputs =
       new GenericSuperstructureIOInputsAutoLogged();
@@ -36,6 +41,9 @@ public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarge
       case POSITION -> {
         superstructureIO.runPosition(positionTarget.getPosition());
       }
+      case POSITION_MANUAL -> {
+        positionTargetManual.ifPresent(superstructureIO::runPosition);
+      }
       case STOP -> {
         superstructureIO.stop();
       }
@@ -55,11 +63,21 @@ public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarge
     this.positionTarget = positionTarget;
   }
 
+  public void setPositionTargetManual(double position){
+    setControlMode(ControlMode.POSITION_MANUAL);
+    positionTargetManual = Optional.of(position);
+  }
+
   public ControlMode getControlMode() {
     return controlMode;
   }
 
   public void setControlMode(ControlMode controlMode) {
+    if(controlMode == ControlMode.POSITION_MANUAL){
+      positionTargetManual = Optional.of(inputs.positionRotations);
+    } else {
+      positionTargetManual = Optional.empty();
+    }
     this.controlMode = controlMode;
   }
 

--- a/src/main/java/frc/robot/subsystems/superstructure/GenericSuperstructure.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/GenericSuperstructure.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.superstructure;
 
 import java.util.Optional;
-
 import org.littletonrobotics.junction.Logger;
 
 public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarget> {
@@ -63,7 +62,7 @@ public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarge
     this.positionTarget = positionTarget;
   }
 
-  public void setPositionTargetManual(double position){
+  public void setPositionTargetManual(double position) {
     setControlMode(ControlMode.POSITION_MANUAL);
     positionTargetManual = Optional.of(position);
   }
@@ -73,7 +72,7 @@ public class GenericSuperstructure<G extends GenericSuperstructure.PositionTarge
   }
 
   public void setControlMode(ControlMode controlMode) {
-    if(controlMode == ControlMode.POSITION_MANUAL){
+    if (controlMode == ControlMode.POSITION_MANUAL) {
       positionTargetManual = Optional.of(inputs.positionRotations);
     } else {
       positionTargetManual = Optional.empty();

--- a/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
@@ -139,7 +139,7 @@ public class Superstructure extends SubsystemBase {
           if(getElevatorPosition() > ElevatorTarget.INTAKE_SIDE.getPosition() && !elevator.reachedTarget()){
             elevator.setPositionTarget(ElevatorTarget.INTAKE_SIDE);
           }else{
-            double calculatedPosition = -Math.sin(getElevatorPosition())*PivotConstants.PIVOT_LENGTH + ElevatorTarget.INTAKE_SIDE.getPosition();// do some math to calculate the elevator position that it needs to be at for the pivot to be at the correct position
+            double calculatedPosition = -Math.sin(getPivotPosition())*PivotConstants.PIVOT_LENGTH + ElevatorTarget.INTAKE_SIDE.getPosition();// do some math to calculate the elevator position that it needs to be at for the pivot to be at the correct position
             elevator.setPositionTargetManual(calculatedPosition);
           }
           tongue.setPositionTarget(TongueTarget.STOW);

--- a/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
@@ -27,8 +27,7 @@ public class Superstructure extends SubsystemBase {
     INTAKE,
     STOW, // Going to the lowest position
     CLIMB,
-    INTAKE_SIDE,
-    SCORE_SIDE,
+    PREVENT_TIPPING,
     ZERO; // Zero the motor
   }
 
@@ -112,7 +111,7 @@ public class Superstructure extends SubsystemBase {
                   || targetState == SuperstructureState.SCORE_L4) {
                 setCurrentState(SuperstructureState.SETUP_L4);
               } else {
-                setCurrentState(SuperstructureState.SCORE_SIDE);
+                setCurrentState(SuperstructureState.PREVENT_TIPPING);
               }
             }
           }
@@ -131,40 +130,52 @@ public class Superstructure extends SubsystemBase {
           }
         }
 
+          // ALL OF OUR TOP TO SCORE_SIDE STATES
+        case PREVENT_TIPPING -> {
+          // this one we have to make the elevator manually go to the correct position to avoid the
+          // pivot touching the intake
 
-        // ALL OF OUR TOP TO SCORE_SIDE STATES
-        case INTAKE_SIDE -> {
-          // this one we have to make the elevator manually go to the correct position to avoid the pivot touching the intake
-          pivot.setPositionTarget(PivotTarget.INTAKE_SIDE);
-          if(getElevatorPosition() > ElevatorTarget.INTAKE_SIDE.getPosition() && !elevator.reachedTarget()){
-            elevator.setPositionTarget(ElevatorTarget.INTAKE_SIDE);
-          }else{
-            double calculatedPosition = -Math.sin(getPivotPosition())*PivotConstants.PIVOT_LENGTH + ElevatorTarget.INTAKE_SIDE.getPosition();// do some math to calculate the elevator position that it needs to be at for the pivot to be at the correct position
-            elevator.setPositionTargetManual(calculatedPosition);
+          // switch our pivot based on our next state
+          switch (targetState) {
+            case SETUP_L4, SCORE_L4, SETUP_L3, SCORE_L3, CLIMB -> pivot.setPositionTarget(
+                PivotTarget.SCORE_SIDE);
+            default -> pivot.setPositionTarget(PivotTarget.INTAKE_SIDE);
           }
-          tongue.setPositionTarget(TongueTarget.STOW);
 
-          if(this.superstructureReachedTarget()){
-            switch (targetState){
-              case TOP -> setCurrentState(SuperstructureState.TOP);
-              case SCORE_SIDE, SETUP_L3, SETUP_L4, SCORE_L3, SCORE_L4, CLIMB -> setCurrentState(SuperstructureState.SCORE_SIDE);
-              default -> setCurrentState(SuperstructureState.TOP);
+          if (pivot.getPosition() > -60.0
+              && (pivot.getPositionTarget() == PivotTarget.INTAKE_SIDE
+                  || (pivot.getPositionTarget() == PivotTarget.SCORE_SIDE
+                      && pivot.getPosition() < 90.0))) { // not in constants
+            elevator.setPositionTarget(ElevatorTarget.INTAKE_SIDE);
+          } else {
+            switch (targetState) { // set elevator pos based on target state
+              case SETUP_L4, SCORE_L4 -> elevator.setPositionTarget(ElevatorTarget.SETUP_L4);
+              case SETUP_L3, SCORE_L3, CLIMB -> {
+                if (pivot.getPosition() > 90.0) {
+                  elevator.setPositionTarget(ElevatorTarget.CLIMB);
+                } else {
+                  elevator.setPositionTarget(ElevatorTarget.TOP);
+                }
+              }
+              default -> elevator.setPositionTarget(ElevatorTarget.TOP);
             }
           }
 
+          if (targetState != SuperstructureState.CLIMB && pivot.getPosition() > 90.0) {
+            tongue.setPositionTarget(TongueTarget.L4);
+          } else {
+            tongue.setPositionTarget(TongueTarget.STOW);
+          }
 
-        }
-        case SCORE_SIDE -> {
-          elevator.setPositionTarget(ElevatorTarget.SCORE_SIDE);
-          pivot.setPositionTarget(PivotTarget.SCORE_SIDE);
-          tongue.setPositionTarget(TongueTarget.STOW);
-
-          if(this.superstructureReachedTarget()){
-            switch (targetState){
-              case INTAKE_SIDE -> setCurrentState(SuperstructureState.INTAKE_SIDE);
+          if (currentState != targetState
+              && elevator.reachedTarget()
+              && (Math.abs(
+                      pivot.getPositionTarget().getPosition() / 360d - pivot.getPosition() / 360d)
+                  < 0.05)) {
+            switch (targetState) {
               case SETUP_L4, SCORE_L4 -> setCurrentState(SuperstructureState.SETUP_L4);
               case SETUP_L3, SCORE_L3, CLIMB -> setCurrentState(SuperstructureState.SETUP_L3);
-              default -> setCurrentState(SuperstructureState.INTAKE_SIDE);
+              default -> setCurrentState(SuperstructureState.TOP);
             }
           }
         }
@@ -174,15 +185,15 @@ public class Superstructure extends SubsystemBase {
           pivot.setPositionTarget(PivotTarget.SETUP_L4);
           tongue.setPositionTarget(TongueTarget.L4);
           // check for state transitions
-          if (this.superstructureReachedTarget()) {
-            switch(targetState){
+          if (currentState != targetState && this.superstructureReachedTarget()) {
+            switch (targetState) {
               case SCORE_L4 -> {
-                if(tonguePoleDetected()){
+                if (tonguePoleDetected()) {
                   setCurrentState(SuperstructureState.SCORE_L4);
                 }
               }
               case SETUP_L3, SCORE_L3, CLIMB -> setCurrentState(SuperstructureState.SETUP_L3);
-              default -> setCurrentState(SuperstructureState.SCORE_SIDE);
+              default -> setCurrentState(SuperstructureState.PREVENT_TIPPING);
             }
           }
         }
@@ -192,9 +203,10 @@ public class Superstructure extends SubsystemBase {
           tongue.setPositionTarget(TongueTarget.STOW);
           // check for state transitions
           if (targetState != currentState && this.superstructureReachedTarget()) {
-            switch(targetState){
-              case SETUP_L4, SETUP_L3, SCORE_L3, CLIMB -> setCurrentState(SuperstructureState.SETUP_L4);
-              default -> setCurrentState(SuperstructureState.SCORE_SIDE);
+            switch (targetState) {
+              case SETUP_L4, SETUP_L3, SCORE_L3, CLIMB -> setCurrentState(
+                  SuperstructureState.SETUP_L4);
+              default -> setCurrentState(SuperstructureState.PREVENT_TIPPING);
             }
           }
         }
@@ -206,9 +218,10 @@ public class Superstructure extends SubsystemBase {
           tongue.setPositionTarget(TongueTarget.TOP);
 
           // check for state transitions
-          if (this.superstructureReachedTarget()) {
-            switch(targetState){
-              case SETUP_L4, SETUP_L3, SCORE_L3, SCORE_L4, CLIMB -> setCurrentState(SuperstructureState.INTAKE_SIDE);
+          if (currentState != targetState && this.superstructureReachedTarget()) {
+            switch (targetState) {
+              case SETUP_L4, SETUP_L3, SCORE_L3, SCORE_L4, CLIMB -> setCurrentState(
+                  SuperstructureState.PREVENT_TIPPING);
               case L2 -> setCurrentState(SuperstructureState.L2);
               case L1 -> setCurrentState(SuperstructureState.L1);
               default -> setCurrentState(SuperstructureState.STOW);
@@ -224,7 +237,7 @@ public class Superstructure extends SubsystemBase {
           tongue.setPositionTarget(TongueTarget.STOW);
 
           // check for state transitions
-          if (this.superstructureReachedTarget()) {
+          if (currentState != targetState && this.superstructureReachedTarget()) {
             if (targetState == SuperstructureState.INTAKE) {
               setCurrentState(SuperstructureState.INTAKE);
             } else if (targetState == SuperstructureState.L1) {
@@ -242,7 +255,7 @@ public class Superstructure extends SubsystemBase {
           tongue.setPositionTarget(TongueTarget.INTAKE);
 
           // check for state transitions
-          if (elevator.reachedTarget()) {
+          if (currentState != targetState && elevator.reachedTarget()) {
             if (targetState == SuperstructureState.STOW) {
               setCurrentState(SuperstructureState.INTAKE);
             } else if (targetState == SuperstructureState.L1) {

--- a/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
@@ -27,6 +27,8 @@ public class Superstructure extends SubsystemBase {
     INTAKE,
     STOW, // Going to the lowest position
     CLIMB,
+    INTAKE_SIDE,
+    SCORE_SIDE,
     ZERO; // Zero the motor
   }
 
@@ -110,7 +112,7 @@ public class Superstructure extends SubsystemBase {
                   || targetState == SuperstructureState.SCORE_L4) {
                 setCurrentState(SuperstructureState.SETUP_L4);
               } else {
-                setCurrentState(SuperstructureState.TOP);
+                setCurrentState(SuperstructureState.SCORE_SIDE);
               }
             }
           }
@@ -128,22 +130,59 @@ public class Superstructure extends SubsystemBase {
             }
           }
         }
+
+
+        // ALL OF OUR TOP TO SCORE_SIDE STATES
+        case INTAKE_SIDE -> {
+          // this one we have to make the elevator manually go to the correct position to avoid the pivot touching the intake
+          pivot.setPositionTarget(PivotTarget.INTAKE_SIDE);
+          if(getElevatorPosition() > ElevatorTarget.INTAKE_SIDE.getPosition() && !elevator.reachedTarget()){
+            elevator.setPositionTarget(ElevatorTarget.INTAKE_SIDE);
+          }else{
+            double calculatedPosition = -Math.sin(getElevatorPosition())*PivotConstants.PIVOT_LENGTH + ElevatorTarget.INTAKE_SIDE.getPosition();// do some math to calculate the elevator position that it needs to be at for the pivot to be at the correct position
+            elevator.setPositionTargetManual(calculatedPosition);
+          }
+          tongue.setPositionTarget(TongueTarget.STOW);
+
+          if(this.superstructureReachedTarget()){
+            switch (targetState){
+              case TOP -> setCurrentState(SuperstructureState.TOP);
+              case SCORE_SIDE, SETUP_L3, SETUP_L4, SCORE_L3, SCORE_L4, CLIMB -> setCurrentState(SuperstructureState.SCORE_SIDE);
+              default -> setCurrentState(SuperstructureState.TOP);
+            }
+          }
+
+
+        }
+        case SCORE_SIDE -> {
+          elevator.setPositionTarget(ElevatorTarget.SCORE_SIDE);
+          pivot.setPositionTarget(PivotTarget.SCORE_SIDE);
+          tongue.setPositionTarget(TongueTarget.STOW);
+
+          if(this.superstructureReachedTarget()){
+            switch (targetState){
+              case INTAKE_SIDE -> setCurrentState(SuperstructureState.INTAKE_SIDE);
+              case SETUP_L4, SCORE_L4 -> setCurrentState(SuperstructureState.SETUP_L4);
+              case SETUP_L3, SCORE_L3, CLIMB -> setCurrentState(SuperstructureState.SETUP_L3);
+              default -> setCurrentState(SuperstructureState.INTAKE_SIDE);
+            }
+          }
+        }
+
         case SETUP_L4 -> {
           elevator.setPositionTarget(ElevatorTarget.SETUP_L4);
           pivot.setPositionTarget(PivotTarget.SETUP_L4);
           tongue.setPositionTarget(TongueTarget.L4);
           // check for state transitions
           if (this.superstructureReachedTarget()) {
-            if (targetState == SuperstructureState.SETUP_L3
-                || targetState == SuperstructureState.SCORE_L3
-                || targetState == SuperstructureState.CLIMB) {
-              setCurrentState(SuperstructureState.SETUP_L3);
-            } else if (targetState == SuperstructureState.SCORE_L4) {
-              if (tonguePoleDetected()) {
-                setCurrentState(SuperstructureState.SCORE_L4);
+            switch(targetState){
+              case SCORE_L4 -> {
+                if(tonguePoleDetected()){
+                  setCurrentState(SuperstructureState.SCORE_L4);
+                }
               }
-            } else if (targetState != currentState) {
-              setCurrentState(SuperstructureState.TOP);
+              case SETUP_L3, SCORE_L3, CLIMB -> setCurrentState(SuperstructureState.SETUP_L3);
+              default -> setCurrentState(SuperstructureState.SCORE_SIDE);
             }
           }
         }
@@ -153,13 +192,9 @@ public class Superstructure extends SubsystemBase {
           tongue.setPositionTarget(TongueTarget.STOW);
           // check for state transitions
           if (targetState != currentState && this.superstructureReachedTarget()) {
-            if (targetState == SuperstructureState.SETUP_L4
-                || targetState == SuperstructureState.SETUP_L3
-                || targetState == SuperstructureState.SCORE_L3
-                || targetState == SuperstructureState.CLIMB) {
-              setCurrentState(SuperstructureState.SETUP_L4);
-            } else {
-              setCurrentState(SuperstructureState.TOP);
+            switch(targetState){
+              case SETUP_L4, SETUP_L3, SCORE_L3, CLIMB -> setCurrentState(SuperstructureState.SETUP_L4);
+              default -> setCurrentState(SuperstructureState.SCORE_SIDE);
             }
           }
         }
@@ -172,19 +207,11 @@ public class Superstructure extends SubsystemBase {
 
           // check for state transitions
           if (this.superstructureReachedTarget()) {
-            if (targetState == SuperstructureState.SETUP_L4
-                || targetState == SuperstructureState.SCORE_L4) {
-              setCurrentState(SuperstructureState.SETUP_L4);
-            } else if (targetState == SuperstructureState.SETUP_L3
-                || targetState == SuperstructureState.SCORE_L3
-                || targetState == SuperstructureState.CLIMB) {
-              setCurrentState(SuperstructureState.SETUP_L3);
-            } else if (targetState == SuperstructureState.L2) {
-              setCurrentState(SuperstructureState.L2);
-            } else if (targetState == SuperstructureState.L1) {
-              setCurrentState(SuperstructureState.L1);
-            } else if (targetState != currentState) {
-              setCurrentState(SuperstructureState.STOW);
+            switch(targetState){
+              case SETUP_L4, SETUP_L3, SCORE_L3, SCORE_L4, CLIMB -> setCurrentState(SuperstructureState.INTAKE_SIDE);
+              case L2 -> setCurrentState(SuperstructureState.L2);
+              case L1 -> setCurrentState(SuperstructureState.L1);
+              default -> setCurrentState(SuperstructureState.STOW);
             }
           }
         }

--- a/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/Superstructure.java
@@ -137,8 +137,8 @@ public class Superstructure extends SubsystemBase {
 
           // switch our pivot based on our next state
           switch (targetState) {
-            case SETUP_L4, SCORE_L4, SETUP_L3, SCORE_L3, CLIMB -> pivot.setPositionTarget(
-                PivotTarget.SCORE_SIDE);
+            case SETUP_L4, SCORE_L4, SETUP_L3, SCORE_L3, CLIMB, PREVENT_TIPPING -> pivot
+                .setPositionTarget(PivotTarget.SCORE_SIDE);
             default -> pivot.setPositionTarget(PivotTarget.INTAKE_SIDE);
           }
 
@@ -147,7 +147,7 @@ public class Superstructure extends SubsystemBase {
                   || (pivot.getPositionTarget() == PivotTarget.SCORE_SIDE
                       && pivot.getPosition() < 90.0))) { // not in constants
             elevator.setPositionTarget(ElevatorTarget.INTAKE_SIDE);
-          } else {
+          } else if (targetState != currentState) {
             switch (targetState) { // set elevator pos based on target state
               case SETUP_L4, SCORE_L4 -> elevator.setPositionTarget(ElevatorTarget.SETUP_L4);
               case SETUP_L3, SCORE_L3, CLIMB -> {
@@ -220,8 +220,12 @@ public class Superstructure extends SubsystemBase {
           // check for state transitions
           if (currentState != targetState && this.superstructureReachedTarget()) {
             switch (targetState) {
-              case SETUP_L4, SETUP_L3, SCORE_L3, SCORE_L4, CLIMB -> setCurrentState(
-                  SuperstructureState.PREVENT_TIPPING);
+              case SETUP_L4,
+                  SETUP_L3,
+                  SCORE_L3,
+                  SCORE_L4,
+                  CLIMB,
+                  PREVENT_TIPPING -> setCurrentState(SuperstructureState.PREVENT_TIPPING);
               case L2 -> setCurrentState(SuperstructureState.L2);
               case L1 -> setCurrentState(SuperstructureState.L1);
               default -> setCurrentState(SuperstructureState.STOW);

--- a/src/main/java/frc/robot/subsystems/superstructure/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/elevator/Elevator.java
@@ -14,7 +14,10 @@ public class Elevator extends GenericSuperstructure<Elevator.ElevatorTarget> {
     SCORE_L4(30),
     TOP(31),
     INTAKE(0),
-    CLIMB(8);
+    CLIMB(8),
+    INTAKE_SIDE(8),
+    SCORE_SIDE(8);
+
     private double position = 0;
 
     private ElevatorTarget(double position) {

--- a/src/main/java/frc/robot/subsystems/superstructure/pivot/Pivot.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/pivot/Pivot.java
@@ -18,8 +18,8 @@ public class Pivot extends GenericSuperstructure<Pivot.PivotTarget> {
     ZERO_HIGH(90),
     SETUP_L4(146),
     SCORE_L4(149),
-    INTAKE_SIDE(0),
-    SCORE_SIDE(140);
+    INTAKE_SIDE(40),
+    SCORE_SIDE(100);
 
     private double position;
 

--- a/src/main/java/frc/robot/subsystems/superstructure/pivot/Pivot.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/pivot/Pivot.java
@@ -17,7 +17,9 @@ public class Pivot extends GenericSuperstructure<Pivot.PivotTarget> {
     ZERO_LOW(-95.2),
     ZERO_HIGH(90),
     SETUP_L4(146),
-    SCORE_L4(149);
+    SCORE_L4(149),
+    INTAKE_SIDE(0),
+    SCORE_SIDE(140);
 
     private double position;
 

--- a/src/main/java/frc/robot/subsystems/superstructure/pivot/PivotConstants.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/pivot/PivotConstants.java
@@ -24,7 +24,7 @@ public class PivotConstants {
 
   public static final MotionMagicConfig MOTION_MAGIC_CONFIG =
       switch (Constants.getRobotType()) {
-        case COMP -> new MotionMagicConfig(3, 10);
+        case COMP -> new MotionMagicConfig(5, 10); // 3, 10
         case PROG -> new MotionMagicConfig(0, 0);
         case ALPHA -> new MotionMagicConfig(0, 0);
         case SIM -> new MotionMagicConfig(0, 0);

--- a/src/main/java/frc/robot/subsystems/superstructure/pivot/PivotConstants.java
+++ b/src/main/java/frc/robot/subsystems/superstructure/pivot/PivotConstants.java
@@ -46,6 +46,7 @@ public class PivotConstants {
   public static final boolean INVERT_MOTOR = true;
 
   public static final double POSITION_TARGET_EPSILON = 0.01;
+  public static final double PIVOT_LENGTH = 25; // inches
 
   // SOFT LIMITS
   public static final Optional<Double> UPPER_EXTENSION_LIMIT = Optional.of(0.465);


### PR DESCRIPTION
Added a new state called PREVENT_TIPPING
This state minimizes the height of the pivot during transitions.
No time lost.
Made pivot go faster because the stability allows it.
Tested it a lot, it works